### PR TITLE
Add testcontainers and Selenide

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,9 @@ dependencies {
     implementation("io.cucumber:cucumber-java:$cucumberVersion")
     implementation("io.cucumber:cucumber-junit:$cucumberVersion")
     implementation("io.cucumber:cucumber-guice:$cucumberVersion")
+
+    implementation("org.testcontainers:selenium:1.12.4")
+    implementation("com.codeborne:selenide:5.6.0")
 }
 
 val cucumberRuntime by configurations.creating {

--- a/src/test/kotlin/io/plagov/steps/BrowserSteps.kt
+++ b/src/test/kotlin/io/plagov/steps/BrowserSteps.kt
@@ -1,0 +1,35 @@
+package io.plagov.steps
+
+import com.codeborne.selenide.Configuration
+import com.codeborne.selenide.Selenide.open
+import com.codeborne.selenide.Selenide.title
+import com.codeborne.selenide.WebDriverRunner
+import io.cucumber.java.en.Given
+import io.kotlintest.shouldBe
+import org.openqa.selenium.chrome.ChromeOptions
+import org.testcontainers.containers.BrowserWebDriverContainer
+
+class BrowserSteps {
+
+    private val browserImage = "selenium/standalone-chrome-debug:3.141.59-yttrium"
+    private val container: BrowserWebDriverContainer<*> = BrowserWebDriverContainer<Nothing>(browserImage).withCapabilities(ChromeOptions())
+
+    @Given("start browser")
+    fun startBrowser() {
+        startBrowserContainer()
+        open("/")
+        title() shouldBe "Google"
+        container.getDockerImageName() shouldBe browserImage
+    }
+
+    private fun startBrowserContainer() {
+        container.start()
+        configureSelenide()
+    }
+
+    private fun configureSelenide() {
+        WebDriverRunner.setWebDriver(container.getWebDriver())
+        Configuration.baseUrl = "https://www.google.com"
+        Configuration.browserSize = "1920x1080"
+    }
+}

--- a/src/test/resources/test.feature
+++ b/src/test/resources/test.feature
@@ -4,3 +4,6 @@ Feature: Smoke test feature
     Given user has 2 apples
     When user gets 2 more apples
     Then user has total of 4 apples
+
+  Scenario: run browser
+    Given start browser


### PR DESCRIPTION
By adding `testcontainers` library, I can strictly specify the version
of a browser to use while running tests.